### PR TITLE
Fix dropdown button shift when opening user selector

### DIFF
--- a/frontend/src/components/PersonSelector.tsx
+++ b/frontend/src/components/PersonSelector.tsx
@@ -92,7 +92,7 @@ const PersonSelector: React.FC<PersonSelectorProps> = ({
   }
 
   return (
-    <div className="relative inline-block" ref={dropdownRef}>
+    <div className="relative inline-block" ref={dropdownRef} style={{ isolation: 'isolate' }}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="w-[240px] flex items-center justify-between px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -109,7 +109,7 @@ const PersonSelector: React.FC<PersonSelectorProps> = ({
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 mt-2 w-[240px] right-0 bg-white rounded-lg shadow-lg border border-gray-200">
+        <div className="absolute z-50 mt-2 min-w-[240px] right-0 bg-white rounded-lg shadow-lg border border-gray-200">
           <div className="py-2">
             {persons.map((person) => (
               <button


### PR DESCRIPTION
## Summary
- Fixed the UI issue where the "Default User" dropdown button shifts to the left when opened
- Changed dropdown menu width from fixed `w-[240px]` to minimum width `min-w-[240px]` to accommodate wider content
- Added CSS isolation to prevent dropdown positioning from affecting the button's layout

## Test plan
- [x] Open the application
- [x] Click on the "Default User" dropdown button in the top right
- [x] Verify that the button doesn't shift position when the dropdown opens
- [x] Verify that the dropdown menu displays correctly with proper alignment
- [x] Test with users that have different content widths (e.g., users with "Default" badge)
- [x] All existing tests pass